### PR TITLE
Enhancement/distance

### DIFF
--- a/src/useStopwatch.js
+++ b/src/useStopwatch.js
@@ -1,51 +1,22 @@
 import { useState, useEffect, useRef } from 'react';
+import { Time } from './utils';
 
 export default function useStopwatch(settings) {
   const { autoStart } = settings || {};
 
   const [seconds, setSeconds] = useState(0);
-  const [minutes, setMinutes] = useState(0);
-  const [hours, setHours] = useState(0);
-  const [days, setDays] = useState(0);
   const intervalRef = useRef();
 
-  function addDay() {
-    setDays((prevDays) => (prevDays + 1));
-  }
-
-  function addHour() {
-    setHours((prevHours) => {
-      if (prevHours === 23) {
-        addDay();
-        return 0;
-      }
-      return prevHours + 1;
-    });
-  }
-
-  function addMinute() {
-    setMinutes((prevMinutes) => {
-      if (prevMinutes === 59) {
-        addHour();
-        return 0;
-      }
-      return prevMinutes + 1;
-    });
-  }
-
-  function addSecond() {
-    setSeconds((prevSeconds) => {
-      if (prevSeconds === 59) {
-        addMinute();
-        return 0;
-      }
-      return prevSeconds + 1;
-    });
+  function clearIntervalRef() {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = undefined;
+    }
   }
 
   function start() {
     if (!intervalRef.current) {
-      intervalRef.current = setInterval(() => addSecond(), 1000);
+      intervalRef.current = setInterval(() => setSeconds((prevSeconds) => (prevSeconds + 1)), 1000);
     }
   }
 
@@ -57,14 +28,11 @@ export default function useStopwatch(settings) {
   }
 
   function reset() {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = undefined;
-    }
+    clearIntervalRef();
     setSeconds(0);
-    setMinutes(0);
-    setHours(0);
-    setDays(0);
+    if (autoStart) {
+      start();
+    }
   }
 
   // didMount effect
@@ -72,10 +40,10 @@ export default function useStopwatch(settings) {
     if (autoStart) {
       start();
     }
-    return reset;
+    return clearIntervalRef;
   }, []);
 
   return {
-    seconds, minutes, hours, days, start, pause, reset,
+    ...Time.getTimeFromSeconds(seconds), start, pause, reset,
   };
 }

--- a/src/useTime.js
+++ b/src/useTime.js
@@ -1,63 +1,33 @@
 import { useState, useEffect, useRef } from 'react';
+import { Time } from './utils';
 
 export default function useTime(settings) {
   const { format } = settings || {};
 
-  const [seconds, setSeconds] = useState(0);
-  const [minutes, setMinutes] = useState(0);
-  const [hours, setHours] = useState(0);
-  const [ampm, setAmPm] = useState('');
+  const [seconds, setSeconds] = useState(Time.getSecondsFromTimeNow());
   const intervalRef = useRef();
 
-  function formatHours(hoursValue) {
-    if (format === '12-hour') {
-      const ampmValue = hoursValue >= 12 ? 'pm' : 'am';
-      let formattedHours = hoursValue % 12;
-      formattedHours = formattedHours || 12;
-      return { hoursValue: formattedHours, ampmValue };
-    }
-    return { hoursValue, ampmValue: '' };
-  }
-
-  function setCurrentTime() {
-    const now = new Date();
-    const secondsValue = now.getSeconds();
-    const minutesValue = now.getMinutes();
-    const { hoursValue, ampmValue } = formatHours(now.getHours());
-
-    setSeconds(secondsValue);
-    setMinutes(minutesValue);
-    setHours(hoursValue);
-    setAmPm(ampmValue);
-  }
-
-
-  function start() {
-    if (!intervalRef.current) {
-      setCurrentTime();
-      intervalRef.current = setInterval(() => setCurrentTime(), 1000);
-    }
-  }
-
-  function reset() {
+  function clearIntervalRef() {
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = undefined;
     }
-    setSeconds(0);
-    setMinutes(0);
-    setHours(0);
-    setAmPm('');
+  }
+
+  function start() {
+    if (!intervalRef.current) {
+      intervalRef.current = setInterval(() => setSeconds(Time.getSecondsFromTimeNow()), 1000);
+    }
   }
 
   // didMount effect
   useEffect(() => {
     start();
-    return reset;
+    return clearIntervalRef;
   }, []);
 
 
   return {
-    seconds, minutes, hours, ampm,
+    ...Time.getFormattedTimeFromSeconds(seconds, format),
   };
 }

--- a/src/useTimer.js
+++ b/src/useTimer.js
@@ -14,13 +14,17 @@ export default function useTimer(settings) {
     }
   }
 
+  function handleExpire() {
+    clearIntervalRef();
+    Validate.onExpire(onExpire) && onExpire();
+  }
+
   function start() {
     if (!intervalRef.current) {
       intervalRef.current = setInterval(() => {
         const secondsValue = Time.getSecondsFromExpiry(expiryTimestamp);
         if (secondsValue <= 0) {
-          clearIntervalRef();
-          Validate.onExpire(onExpire) && onExpire();
+          handleExpire();
         }
         setSeconds(secondsValue);
       }, 1000);
@@ -33,7 +37,13 @@ export default function useTimer(settings) {
 
   function resume() {
     if (!intervalRef.current) {
-      intervalRef.current = setInterval(() => setSeconds((prevSeconds) => (prevSeconds - 1)), 1000);
+      intervalRef.current = setInterval(() => setSeconds((prevSeconds) => {
+        const secondsValue = prevSeconds - 1;
+        if (secondsValue <= 0) {
+          handleExpire();
+        }
+        return secondsValue;
+      }), 1000);
     }
   }
 

--- a/src/useTimer.js
+++ b/src/useTimer.js
@@ -1,148 +1,57 @@
 import { useState, useEffect, useRef } from 'react';
-
-
-function isValidExpiryTimestamp(expiryTimestamp) {
-  const isValid = (new Date(expiryTimestamp)).getTime() > 0;
-  if (!isValid) {
-    console.warn('react-timer-hook: { useTimer } Invalid expiryTimestamp settings', expiryTimestamp);
-  }
-  return isValid;
-}
-
-function isValidOnExpire(onExpire) {
-  const isValid = onExpire && typeof onExpire === 'function';
-  if (onExpire && !isValid) {
-    console.warn('react-timer-hook: { useTimer } Invalid onExpire settings function', onExpire);
-  }
-  return isValid;
-}
+import { Time, Validate } from './utils';
 
 export default function useTimer(settings) {
   const { expiryTimestamp: expiry, onExpire } = settings || {};
   const [expiryTimestamp, setExpiryTimestamp] = useState(expiry);
-
-  const [seconds, setSeconds] = useState(0);
-  const [minutes, setMinutes] = useState(0);
-  const [hours, setHours] = useState(0);
-  const [days, setDays] = useState(0);
+  const [seconds, setSeconds] = useState(Time.getSecondsFromExpiry(expiryTimestamp));
   const intervalRef = useRef();
 
-  function reset() {
+  function clearIntervalRef() {
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = undefined;
-    }
-    setSeconds(0);
-    setMinutes(0);
-    setHours(0);
-    setDays(0);
-  }
-
-  function subtractDay() {
-    setDays((prevDays) => {
-      if (prevDays > 0) {
-        return prevDays - 1;
-      }
-      reset();
-      isValidOnExpire(onExpire) && onExpire();
-      return 0;
-    });
-  }
-
-  function subtractHour() {
-    setHours((prevHours) => {
-      if (prevHours === 0) {
-        subtractDay();
-        return 23;
-      }
-
-      if (prevHours > 0) {
-        return prevHours - 1;
-      }
-      return 0;
-    });
-  }
-
-  function subtractMinute() {
-    setMinutes((prevMinutes) => {
-      if (prevMinutes === 0) {
-        subtractHour();
-        return 59;
-      }
-
-      if (prevMinutes > 0) {
-        return prevMinutes - 1;
-      }
-      return 0;
-    });
-  }
-
-  function subtractSecond() {
-    setSeconds((prevSeconds) => {
-      if (prevSeconds === 0) {
-        subtractMinute();
-        return 59;
-      }
-
-      if (prevSeconds > 0) {
-        return prevSeconds - 1;
-      }
-      return 0;
-    });
-  }
-
-  // Timer expiry date calculation
-  function calculateExpiryDate() {
-    const now = new Date().getTime();
-    const distance = expiryTimestamp - now;
-    const daysValue = Math.floor(distance / (1000 * 60 * 60 * 24));
-    const hoursValue = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    const minutesValue = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-    const secondsValue = Math.floor((distance % (1000 * 60)) / 1000);
-    if (secondsValue < 0) {
-      reset();
-      isValidOnExpire(onExpire) && onExpire();
-    } else {
-      setSeconds(secondsValue);
-      setMinutes(minutesValue);
-      setHours(hoursValue);
-      setDays(daysValue);
     }
   }
 
   function start() {
-    if (isValidExpiryTimestamp(expiryTimestamp) && !intervalRef.current) {
-      calculateExpiryDate();
-      intervalRef.current = setInterval(() => calculateExpiryDate(), 1000);
+    if (!intervalRef.current) {
+      intervalRef.current = setInterval(() => {
+        const secondsValue = Time.getSecondsFromExpiry(expiryTimestamp);
+        if (secondsValue <= 0) {
+          clearIntervalRef();
+          Validate.onExpire(onExpire) && onExpire();
+        }
+        setSeconds(secondsValue);
+      }, 1000);
     }
   }
 
   function pause() {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = undefined;
-    }
+    clearIntervalRef();
   }
 
   function resume() {
-    if (isValidExpiryTimestamp(expiryTimestamp) && !intervalRef.current) {
-      intervalRef.current = setInterval(() => subtractSecond(), 1000);
+    if (!intervalRef.current) {
+      intervalRef.current = setInterval(() => setSeconds((prevSeconds) => (prevSeconds - 1)), 1000);
     }
   }
 
   function restart(newExpiryTimestamp) {
-    reset();
+    clearIntervalRef();
     setExpiryTimestamp(newExpiryTimestamp);
   }
 
-  // didMount effect
   useEffect(() => {
-    start();
-    return reset;
+    if (Validate.expiryTimestamp(expiryTimestamp)) {
+      setSeconds(Time.getSecondsFromExpiry(expiryTimestamp));
+      start();
+    }
+    return clearIntervalRef;
   }, [expiryTimestamp]);
 
 
   return {
-    seconds, minutes, hours, days, start, pause, resume, restart,
+    ...Time.getTimeFromSeconds(seconds), start, pause, resume, restart,
   };
 }

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -21,4 +21,29 @@ export default class Time {
     }
     return 0;
   }
+
+  static getSecondsFromTimeNow() {
+    const now = new Date();
+    const currentTimestamp = now.getTime();
+    const offset = (now.getTimezoneOffset() * 60);
+    return (currentTimestamp / 1000) - offset;
+  }
+
+  static getFormattedTimeFromSeconds(totalSeconds, format) {
+    const { seconds: secondsValue, minutes, hours } = Time.getTimeFromSeconds(totalSeconds);
+    let ampm = '';
+    let hoursValue = hours;
+
+    if (format === '12-hour') {
+      ampm = hours >= 12 ? 'pm' : 'am';
+      hoursValue = hours % 12;
+    }
+
+    return {
+      seconds: secondsValue,
+      minutes,
+      hours: hoursValue,
+      ampm,
+    };
+  }
 }

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -1,0 +1,24 @@
+export default class Time {
+  static getTimeFromSeconds(totalSeconds) {
+    const days = Math.floor(totalSeconds / (60 * 60 * 24));
+    const hours = Math.floor((totalSeconds % (60 * 60 * 24)) / (60 * 60));
+    const minutes = Math.floor((totalSeconds % (60 * 60)) / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+
+    return {
+      seconds,
+      minutes,
+      hours,
+      days,
+    };
+  }
+
+  static getSecondsFromExpiry(expiry) {
+    const now = new Date().getTime();
+    const milliSecondsDistance = expiry - now;
+    if (milliSecondsDistance > 0) {
+      return Math.floor(milliSecondsDistance / 1000);
+    }
+    return 0;
+  }
+}

--- a/src/utils/Validate.js
+++ b/src/utils/Validate.js
@@ -1,0 +1,17 @@
+export default class Validate {
+  static expiryTimestamp(expiryTimestamp) {
+    const isValid = (new Date(expiryTimestamp)).getTime() > 0;
+    if (!isValid) {
+      console.warn('react-timer-hook: { useTimer } Invalid expiryTimestamp settings', expiryTimestamp); // eslint-disable-line
+    }
+    return isValid;
+  }
+
+  static onExpire(onExpire) {
+    const isValid = onExpire && typeof onExpire === 'function';
+    if (onExpire && !isValid) {
+      console.warn('react-timer-hook: { useTimer } Invalid onExpire settings function', onExpire); // eslint-disable-line
+    }
+    return isValid;
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,7 @@
+import Time from './Time';
+import Validate from './Validate';
+
+export {
+  Time,
+  Validate,
+};


### PR DESCRIPTION
## Use only distance in `seconds` as state in all hooks, and calculate rest of time attributes based on `seconds`

1. Change how all hooks state work, move from separate individual states `seconds`, `minutes`, `hours`, and `days` state to single total `seconds` state, and calculate all time attributes based on total seconds only, this will limit number of renders to be single render per second

2. Move all validation functions to `Validate` util

3. Create `Time` util to handle all total `seconds` to time conversion and time formatting functions

4. Fix update `format` props in `useTime` 