### PR TITLE
fix: Fix type for time returns; should have a `totalSeconds` property…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timer-hook",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "React timer hook is a custom react hook built to handle timers(countdown), stopwatch and time logic/state in your react component.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "prepare": "npm run build:prod",
     "build:demo": "rm -rf ./docs && webpack --config webpack.dev.js && webpack-dev-server --open --config webpack.dev.js",
     "build:prod": "rm -rf ./dist && webpack --config webpack.prod.js",
     "lint": "node_modules/.bin/eslint src"

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ import { useTimer } from 'react-timer-hook';
 
 function MyTimer({ expiryTimestamp }) {
   const {
+    totalSeconds,
     seconds,
     minutes,
     hours,
@@ -105,6 +106,7 @@ import { useStopwatch } from 'react-timer-hook';
 
 function MyStopwatch() {
   const {
+    totalSeconds,
     seconds,
     minutes,
     hours,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ interface TimerSettings {
 }
 
 interface TimerResult {
+    totalSeconds: number;
     seconds: number;
     minutes: number;
     hours: number;
@@ -24,6 +25,7 @@ interface StopwatchSettings {
 }
 
 interface StopwatchResult {
+    totalSeconds: number;
     seconds: number;
     minutes: number;
     hours: number;


### PR DESCRIPTION
… because Time.getTimeFromSeconds() returns it.

Fixes error caused by `totalSeconds` not being declared for the returns.
Updated docs to reflect update.