### PR TITLE
add 24-hour format option to use Time hook for clarity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ export default function App() {
 
 | key | Type | Required | Description |
 | --- | --- | --- | ---- |
-| format | string | No | if set to `12-hour` time will be formatted with am/pm |
+| format | string | No | By default, the format is `24-hour`. If set to `12-hour`, time will be formatted with am/pm |
 | interval | number | No | value to change the interval of the time, by default it is set to 1000ms. Note: this value will not affect the thime, it will just define the frequency used to calculate the current time values. For example, if you have a use case where milliseconds are used, you need to use a smaller value for the interval, for example, 20ms or 100ms based on your needs. |
 
 ### Values

--- a/src/useTime.ts
+++ b/src/useTime.ts
@@ -5,11 +5,11 @@ import { SECOND_INTERVAL } from './constants';
 import { FormattedTimeFromMillisecondsType } from './utils/Time';
 
 export type useTimeSettingsType = {
-  format?: '12-hour',
+  format?: '24-hour' | '12-hour',
   interval?: number;
 };
 
-export default function useTime({ format, interval: customInterval = SECOND_INTERVAL }: useTimeSettingsType = {}): FormattedTimeFromMillisecondsType {
+export default function useTime({ format = '24-hour', interval: customInterval = SECOND_INTERVAL }: useTimeSettingsType = {}): FormattedTimeFromMillisecondsType {
   const [milliseconds, setMilliseconds] = useState(Time.getMillisecondsFromTimeNow());
 
   useInterval(() => {

--- a/src/utils/Time.ts
+++ b/src/utils/Time.ts
@@ -59,7 +59,7 @@ export default class Time {
     return currentTimestamp - offset;
   }
 
-  static getFormattedTimeFromMilliseconds(milliseconds: number, format?: '12-hour'): FormattedTimeFromMillisecondsType {
+  static getFormattedTimeFromMilliseconds(milliseconds: number, format?: '12-hour' | '24-hour'): FormattedTimeFromMillisecondsType {
     const {
       milliseconds: millisecVal,
       seconds: secondsValue,


### PR DESCRIPTION
### Description:
This PR explicitly adds the `24-hour` format option to the `useTime` hook. Previously, the `24-hour` format was the default but was not explicitly mentioned. This change improves clarity by making the format option clear in the code.

### Changes:
- Added explicit support for the `24-hour` format option in the `useTime` hook.
- Updated documentation to reflect the default format and the available options.

### Why this change:
This change helps improve code readability and clarity, ensuring that the default format is explicitly defined as `24-hour` while still supporting the `12-hour` format option.
